### PR TITLE
v3.0.01 - Fix PHP warnings for systems without Mcrypt installed

### DIFF
--- a/Credentials/CHANGEDB.php
+++ b/Credentials/CHANGEDB.php
@@ -109,3 +109,8 @@ ALTER TABLE `credentialsCredential` CHANGE COLUMN `credentialsWebsiteID` `creden
 ALTER TABLE `credentialsCredential` ADD COLUMN `encryptAlgorithm` VARCHAR(15) NULL DEFAULT 'openssl' AFTER `password`;end
 UPDATE `credentialsCredential` SET `encryptAlgorithm` = 'mcrypt' WHERE password IS NOT NULL AND password != '';end
 ";
+
+//3.0.01
+++$count;
+$sql[$count][0] = '3.0.01';
+$sql[$count][1] = "";

--- a/Credentials/CHANGELOG.txt
+++ b/Credentials/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v3.0.01
+-------
+Fix PHP warnings for systems without Mcrypt installed
+
 v3.0.00
 -------
 Object oriented rewrite and code cleanup

--- a/Credentials/manifest.php
+++ b/Credentials/manifest.php
@@ -25,7 +25,7 @@ $description = 'Credentials is a module for storing student login details, and m
 $entryURL = 'credentials.php';
 $type = 'Additional';
 $category = 'Admin';
-$version = '3.0.00';
+$version = '3.0.01';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/Credentials/moduleFunctions.php
+++ b/Credentials/moduleFunctions.php
@@ -157,8 +157,8 @@ function getDecryptCredentialOpenssl($password) {
 }
 
 // 
-define('SAFETY_CIPHER', MCRYPT_RIJNDAEL_256);
-define('SAFETY_MODE', MCRYPT_MODE_CFB);
+define('SAFETY_CIPHER', defined('MCRYPT_RIJNDAEL_256') ? MCRYPT_RIJNDAEL_256 : 'MCRYPT_RIJNDAEL_256');
+define('SAFETY_MODE', defined('MCRYPT_MODE_CFB') ? MCRYPT_MODE_CFB : 'MCRYPT_MODE_CFB');
 
 function changeMcryptToOpenssl($password){
     $key = substr(md5(APPLICATION_WIDE_PASSPHRASE), 0, mcrypt_get_key_size(SAFETY_CIPHER, SAFETY_MODE));

--- a/Credentials/version.php
+++ b/Credentials/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '3.0.00';
+$moduleVersion = '3.0.01';


### PR DESCRIPTION
Credentials was updated to add a system to convert old mcrypt credentials to openssl. Currently, if a system does not have mcrypt installed, PHP will show a warning:

`Warning: Use of undefined constant MCRYPT_RIJNDAEL_256 - assumed 'MCRYPT_RIJNDAEL_256' (this will throw an Error in a future version of PHP)`

This PR suppresses the warning by optionally passing the constant as a string, which the mcrypt function will also accept.